### PR TITLE
Add working directory flag to allow use of action from non-root directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ Default is `false`.
 
 Optional. Additional reviewdog flags.
 
+### `workdir`
+
+Optional. The directory from which to look for and run Rubocop. Default '.'
+
 ## Example usage
 
 ```yml

--- a/action.yml
+++ b/action.yml
@@ -37,6 +37,9 @@ inputs:
   reviewdog_flags:
     description: 'Additional reviewdog flags'
     default: ''
+  workdir:
+    description: "The directory from which to look for and run Rubocop. Default '.'"
+    default: '.'
 runs:
   using: 'docker'
   image: 'Dockerfile'
@@ -51,6 +54,7 @@ runs:
     - ${{ inputs.filter_mode }}
     - ${{ inputs.fail_on_error }}
     - ${{ inputs.reviewdog_flags }}
+    - ${{ inputs.workdir }}
 branding:
   icon: 'check-circle'
   color: 'red'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,7 +5,7 @@ version() {
   fi
 }
 
-cd "$GITHUB_WORKSPACE"
+cd "${GITHUB_WORKSPACE}/${INPUT_WORKDIR}" || exit 1
 
 export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
 


### PR DESCRIPTION
Useful when subprojects in repository.