### PR TITLE
Add ability to parse Gemfile.lock for current rubocop version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,9 @@ FROM ruby:2.6-alpine
 ENV REVIEWDOG_VERSION v0.10.2
 
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
-RUN apk add --update --no-cache build-base git grep # hadolint ignore=DL3018
+
+# hadolint ignore=DL3018
+RUN apk add --update --no-cache build-base git grep
 RUN wget -O - -q https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh| sh -s -- -b /usr/local/bin/ $REVIEWDOG_VERSION
 
 COPY entrypoint.sh /entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,7 @@ FROM ruby:2.6-alpine
 ENV REVIEWDOG_VERSION v0.10.2
 
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
-RUN apk add --update --no-cache build-base git
-RUN apk add --update --no-cache grep=3.4-r0
+RUN apk add --update --no-cache build-base git grep # hadolint ignore=DL3018
 RUN wget -O - -q https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh| sh -s -- -b /usr/local/bin/ $REVIEWDOG_VERSION
 
 COPY entrypoint.sh /entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ FROM ruby:2.6-alpine
 ENV REVIEWDOG_VERSION v0.10.2
 
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
-RUN apk add --update --no-cache build-base git grep
+RUN apk add --update --no-cache build-base git
+RUN apk add --update --no-cache grep=3.4-r0
 RUN wget -O - -q https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh| sh -s -- -b /usr/local/bin/ $REVIEWDOG_VERSION
 
 COPY entrypoint.sh /entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM ruby:2.6-alpine
 ENV REVIEWDOG_VERSION v0.10.2
 
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
-RUN apk add --update --no-cache build-base git
+RUN apk add --update --no-cache build-base git grep
 RUN wget -O - -q https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh| sh -s -- -b /usr/local/bin/ $REVIEWDOG_VERSION
 
 COPY entrypoint.sh /entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -33,14 +33,24 @@ With `reporter: github-pr-review` a comment is added to the Pull Request Convers
 
 ### `rubocop_version`
 
-Optional. Set rubocop version. 
-By default install latest version.
+Optional. Set rubocop version. Possible values:
+* empty or omit: install latest version
+* `latest`: install version from Gemfile (`Gemfile.lock` should be presented, otherwise it will fallback to latest bundler version)
+* version (e.g. `0.90.0`): install said version
 
 ### `rubocop_extensions`
 
 Optional. Set list of rubocop extensions with versions. 
 
 By default install `rubocop-rails`, `rubocop-performance`, `rubocop-rspec`, `rubocop-i18n`, `rubocop-rake` with latest versions.
+Provide desired version delimited by `:` (e.g. `rubocop-rails:1.7.1`)
+
+Possible version values:
+* empty or omit (`rubocop-rails rubocop-rspec`): install latest version
+* `rubocop-rails:latest rubocop-rspec:latest`: install version from Gemfile (`Gemfile.lock` should be presented, otherwise it will fallback to latest bundler version)
+* version (e.g. `rubocop-rails:1.7.1 rubocop-rspec:2.0.0`): install said version
+
+You can combine `latest`, fixed and latest bundle version as you want to.
 
 ### `rubocop_flags`
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ With `reporter: github-pr-review` a comment is added to the Pull Request Convers
 
 Optional. Set rubocop version. Possible values:
 * empty or omit: install latest version
-* `latest`: install version from Gemfile (`Gemfile.lock` should be presented, otherwise it will fallback to latest bundler version)
+* `gemfile`: install version from Gemfile (`Gemfile.lock` should be presented, otherwise it will fallback to latest bundler version)
 * version (e.g. `0.90.0`): install said version
 
 ### `rubocop_extensions`
@@ -47,10 +47,10 @@ Provide desired version delimited by `:` (e.g. `rubocop-rails:1.7.1`)
 
 Possible version values:
 * empty or omit (`rubocop-rails rubocop-rspec`): install latest version
-* `rubocop-rails:latest rubocop-rspec:latest`: install version from Gemfile (`Gemfile.lock` should be presented, otherwise it will fallback to latest bundler version)
+* `rubocop-rails:gemfile rubocop-rspec:gemfile`: install version from Gemfile (`Gemfile.lock` should be presented, otherwise it will fallback to latest bundler version)
 * version (e.g. `rubocop-rails:1.7.1 rubocop-rspec:2.0.0`): install said version
 
-You can combine `latest`, fixed and latest bundle version as you want to.
+You can combine `gemfile`, fixed and latest bundle version as you want to.
 
 ### `rubocop_flags`
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,8 +9,8 @@ cd "${GITHUB_WORKSPACE}/${INPUT_WORKDIR}" || exit 1
 
 export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
 
-# if 'latest' rubocop version selected
-if [[ $INPUT_RUBOCOP_VERSION = "latest" ]]; then
+# if 'gemfile' rubocop version selected
+if [[ $INPUT_RUBOCOP_VERSION = "gemfile" ]]; then
   # if Gemfile.lock is here
   if [[ -f 'Gemfile.lock' ]]; then
     # grep for rubocop version
@@ -20,7 +20,11 @@ if [[ $INPUT_RUBOCOP_VERSION = "latest" ]]; then
     # left it empty otherwise, so no version will be passed
     if [[ -n "$RUBOCOP_GEMFILE_VERSION" ]]; then
       RUBOCOP_VERSION=$RUBOCOP_GEMFILE_VERSION
+      else
+        printf "Cannot get the rubocop's version from Gemfile.lock. The latest version will be installed."
     fi
+    else
+      printf 'Gemfile.lock not found. The latest version will be installed.'
   fi
   else
     # set desired rubocop version
@@ -35,8 +39,8 @@ for extension in $INPUT_RUBOCOP_EXTENSIONS; do
   INPUT_RUBOCOP_EXTENSION_NAME=`echo $extension | grep -oP '^rubocop-\w*'`
   INPUT_RUBOCOP_EXTENSION_VERSION=`echo $extension | grep -oP '^rubocop-\w*:\K(.*)'`
 
-  # if version is 'latest'
-  if [[ $INPUT_RUBOCOP_EXTENSION_VERSION = "latest" ]]; then
+  # if version is 'gemfile'
+  if [[ $INPUT_RUBOCOP_EXTENSION_VERSION = "gemfile" ]]; then
     # if Gemfile.lock is here
     if [[ -f 'Gemfile.lock' ]]; then
       # grep for rubocop extension version
@@ -46,7 +50,11 @@ for extension in $INPUT_RUBOCOP_EXTENSIONS; do
       # left it empty otherwise, so no version will be passed
       if [[ -n "$RUBOCOP_EXTENSION_GEMFILE_VERSION" ]]; then
         RUBOCOP_EXTENSION_VERSION=$RUBOCOP_EXTENSION_GEMFILE_VERSION
+        else
+          printf "Cannot get the rubocop extension version from Gemfile.lock. The latest version will be installed."
       fi
+      else
+        printf 'Gemfile.lock not found. The latest version will be installed.'
     fi
   else
     # set desired rubocop extension version

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,9 +9,52 @@ cd "${GITHUB_WORKSPACE}/${INPUT_WORKDIR}" || exit 1
 
 export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
 
-gem install -N rubocop $(version $INPUT_RUBOCOP_VERSION)
+# if 'latest' rubocop version selected
+if [[ $INPUT_RUBOCOP_VERSION = "latest" ]]; then
+  # if Gemfile.lock is here
+  if [[ -f 'Gemfile.lock' ]]; then
+    # grep for rubocop version
+    RUBOCOP_GEMFILE_VERSION=`cat Gemfile.lock | grep -oP '^\s{4}rubocop\s\(\K.*(?=\))'`
 
-echo $INPUT_RUBOCOP_EXTENSIONS | xargs gem install -N
+    # if rubocop version found, then pass it to the gem install
+    # left it empty otherwise, so no version will be passed
+    if [[ -n "$RUBOCOP_GEMFILE_VERSION" ]]; then
+      RUBOCOP_VERSION=$RUBOCOP_GEMFILE_VERSION
+    fi
+  fi
+  else
+    # set desired rubocop version
+    RUBOCOP_VERSION=$INPUT_RUBOCOP_VERSION
+fi
+
+gem install -N rubocop $(version $RUBOCOP_VERSION)
+
+# Traverse over list of rubocop extensions
+for extension in $INPUT_RUBOCOP_EXTENSIONS; do
+  # grep for name and version
+  INPUT_RUBOCOP_EXTENSION_NAME=`echo $extension | grep -oP '^rubocop-\w*'`
+  INPUT_RUBOCOP_EXTENSION_VERSION=`echo $extension | grep -oP '^rubocop-\w*:\K(.*)'`
+
+  # if version is 'latest'
+  if [[ $INPUT_RUBOCOP_EXTENSION_VERSION = "latest" ]]; then
+    # if Gemfile.lock is here
+    if [[ -f 'Gemfile.lock' ]]; then
+      # grep for rubocop extension version
+      RUBOCOP_EXTENSION_GEMFILE_VERSION=`cat Gemfile.lock | grep -oP "^\s{4}$INPUT_RUBOCOP_EXTENSION_NAME\s\(\K.*(?=\))"`
+
+      # if rubocop extension version found, then pass it to the gem install
+      # left it empty otherwise, so no version will be passed
+      if [[ -n "$RUBOCOP_EXTENSION_GEMFILE_VERSION" ]]; then
+        RUBOCOP_EXTENSION_VERSION=$RUBOCOP_EXTENSION_GEMFILE_VERSION
+      fi
+    fi
+  else
+    # set desired rubocop extension version
+    RUBOCOP_EXTENSION_VERSION=$INPUT_RUBOCOP_EXTENSION_VERSION
+  fi
+
+  gem install -N $INPUT_RUBOCOP_EXTENSION_NAME $(version $RUBOCOP_EXTENSION_VERSION)
+done
 
 rubocop ${INPUT_RUBOCOP_FLAGS} \
   | reviewdog -f=rubocop \


### PR DESCRIPTION
So with that addition you can tell action to grep `Gemfile.lock` (if there is such file), and get current versions of rubocop and extensions, then install and use those versions.
If no version provided or fixed (`0.90.0` for example) version is provided, then no changes, action will install latest bundler or fixed version of rubocop and extensions.

**Note:** I added `grep` to the `Dockerfile` in order to use GNU grep with PCRE support. Also added some information about new feature to the README.