### PR TITLE
Address issues with extension filtering

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV REVIEWDOG_VERSION v0.10.2
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 
 # hadolint ignore=DL3018
-RUN apk add --update --no-cache build-base git grep
+RUN apk add --update --no-cache build-base git grep pcre-tools
 RUN wget -O - -q https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh| sh -s -- -b /usr/local/bin/ $REVIEWDOG_VERSION
 
 COPY entrypoint.sh /entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV REVIEWDOG_VERSION v0.10.2
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 
 # hadolint ignore=DL3018
-RUN apk add --update --no-cache build-base git grep pcre-tools
+RUN apk add --update --no-cache build-base git pcre-tools
 RUN wget -O - -q https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh| sh -s -- -b /usr/local/bin/ $REVIEWDOG_VERSION
 
 COPY entrypoint.sh /entrypoint.sh

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -36,8 +36,8 @@ gem install -N rubocop $(version $RUBOCOP_VERSION)
 # Traverse over list of rubocop extensions
 for extension in $INPUT_RUBOCOP_EXTENSIONS; do
   # grep for name and version
-  INPUT_RUBOCOP_EXTENSION_NAME=`echo $extension | grep -oP '^rubocop-\w*'`
-  INPUT_RUBOCOP_EXTENSION_VERSION=`echo $extension | grep -oP '^rubocop-\w*:\K(.*)'`
+  INPUT_RUBOCOP_EXTENSION_NAME=`echo $extension |awk 'BEGIN { FS = ":" } ; { print $1 }')`
+  INPUT_RUBOCOP_EXTENSION_VERSION=`echo $extension |awk 'BEGIN { FS = ":" } ; { print $2 }')`
 
   # if version is 'gemfile'
   if [[ $INPUT_RUBOCOP_EXTENSION_VERSION = "gemfile" ]]; then
@@ -61,7 +61,14 @@ for extension in $INPUT_RUBOCOP_EXTENSIONS; do
     RUBOCOP_EXTENSION_VERSION=$INPUT_RUBOCOP_EXTENSION_VERSION
   fi
 
-  gem install -N $INPUT_RUBOCOP_EXTENSION_NAME $(version $RUBOCOP_EXTENSION_VERSION)
+  # Handle extensions with no version qualifier
+  if [ -z "${RUBOCOP_EXTENSION_VERSION}" ]; then
+    unset RUBOCOP_EXTENSION_VERSION_FLAG
+  else
+    RUBOCOP_EXTENSION_VERSION_FLAG="--version ${RUBOCOP_EXTENSION_VERSION}"
+  fi
+
+  gem install -N ${INPUT_RUBOCOP_EXTENSION_NAME} ${RUBOCOP_EXTENSION_VERSION_FLAG}
 done
 
 rubocop ${INPUT_RUBOCOP_FLAGS} \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,15 +10,15 @@ cd "${GITHUB_WORKSPACE}/${INPUT_WORKDIR}" || exit 1
 export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
 
 # if 'gemfile' rubocop version selected
-if [[ $INPUT_RUBOCOP_VERSION = "gemfile" ]]; then
+if [ "${INPUT_RUBOCOP_VERSION}" = "gemfile" ]; then
   # if Gemfile.lock is here
-  if [[ -f 'Gemfile.lock' ]]; then
+  if [ -f 'Gemfile.lock' ]; then
     # grep for rubocop version
-    RUBOCOP_GEMFILE_VERSION=`cat Gemfile.lock | grep -oP '^\s{4}rubocop\s\(\K.*(?=\))'`
+    RUBOCOP_GEMFILE_VERSION=$(pcregrep -o '^\s{4}rubocop\s\(\K.*(?=\))' Gemfile.lock)
 
     # if rubocop version found, then pass it to the gem install
     # left it empty otherwise, so no version will be passed
-    if [[ -n "$RUBOCOP_GEMFILE_VERSION" ]]; then
+    if [ -n "$RUBOCOP_GEMFILE_VERSION" ]; then
       RUBOCOP_VERSION=$RUBOCOP_GEMFILE_VERSION
       else
         printf "Cannot get the rubocop's version from Gemfile.lock. The latest version will be installed."
@@ -31,24 +31,24 @@ if [[ $INPUT_RUBOCOP_VERSION = "gemfile" ]]; then
     RUBOCOP_VERSION=$INPUT_RUBOCOP_VERSION
 fi
 
-gem install -N rubocop $(version $RUBOCOP_VERSION)
+gem install -N rubocop --version "${RUBOCOP_VERSION}"
 
 # Traverse over list of rubocop extensions
 for extension in $INPUT_RUBOCOP_EXTENSIONS; do
   # grep for name and version
-  INPUT_RUBOCOP_EXTENSION_NAME=`echo $extension |awk 'BEGIN { FS = ":" } ; { print $1 }')`
-  INPUT_RUBOCOP_EXTENSION_VERSION=`echo $extension |awk 'BEGIN { FS = ":" } ; { print $2 }')`
+  INPUT_RUBOCOP_EXTENSION_NAME=$(echo "$extension" |awk 'BEGIN { FS = ":" } ; { print $1 }')
+  INPUT_RUBOCOP_EXTENSION_VERSION=$(echo "$extension" |awk 'BEGIN { FS = ":" } ; { print $2 }')
 
   # if version is 'gemfile'
-  if [[ $INPUT_RUBOCOP_EXTENSION_VERSION = "gemfile" ]]; then
+  if [ "${INPUT_RUBOCOP_EXTENSION_VERSION}" = "gemfile" ]; then
     # if Gemfile.lock is here
-    if [[ -f 'Gemfile.lock' ]]; then
+    if [ -f 'Gemfile.lock' ]; then
       # grep for rubocop extension version
-      RUBOCOP_EXTENSION_GEMFILE_VERSION=`cat Gemfile.lock | grep -oP "^\s{4}$INPUT_RUBOCOP_EXTENSION_NAME\s\(\K.*(?=\))"`
+      RUBOCOP_EXTENSION_GEMFILE_VERSION=$(pcregrep -o "^\s{4}$INPUT_RUBOCOP_EXTENSION_NAME\s\(\K.*(?=\))" Gemfile.lock)
 
       # if rubocop extension version found, then pass it to the gem install
       # left it empty otherwise, so no version will be passed
-      if [[ -n "$RUBOCOP_EXTENSION_GEMFILE_VERSION" ]]; then
+      if [ -n "$RUBOCOP_EXTENSION_GEMFILE_VERSION" ]; then
         RUBOCOP_EXTENSION_VERSION=$RUBOCOP_EXTENSION_GEMFILE_VERSION
         else
           printf "Cannot get the rubocop extension version from Gemfile.lock. The latest version will be installed."
@@ -68,14 +68,14 @@ for extension in $INPUT_RUBOCOP_EXTENSIONS; do
     RUBOCOP_EXTENSION_VERSION_FLAG="--version ${RUBOCOP_EXTENSION_VERSION}"
   fi
 
-  gem install -N ${INPUT_RUBOCOP_EXTENSION_NAME} ${RUBOCOP_EXTENSION_VERSION_FLAG}
+  gem install -N "${INPUT_RUBOCOP_EXTENSION_NAME}" "${RUBOCOP_EXTENSION_VERSION_FLAG}"
 done
 
-rubocop ${INPUT_RUBOCOP_FLAGS} \
+rubocop "${INPUT_RUBOCOP_FLAGS}" \
   | reviewdog -f=rubocop \
       -name="${INPUT_TOOL_NAME}" \
       -reporter="${INPUT_REPORTER}" \
       -filter-mode="${INPUT_FILTER_MODE}" \
       -fail-on-error="${INPUT_FAIL_ON_ERROR}" \
       -level="${INPUT_LEVEL}" \
-      ${INPUT_REVIEWDOG_FLAGS}
+      "${INPUT_REVIEWDOG_FLAGS}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -68,10 +68,12 @@ for extension in $INPUT_RUBOCOP_EXTENSIONS; do
     RUBOCOP_EXTENSION_VERSION_FLAG="--version ${RUBOCOP_EXTENSION_VERSION}"
   fi
 
-  gem install -N "${INPUT_RUBOCOP_EXTENSION_NAME}" "${RUBOCOP_EXTENSION_VERSION_FLAG}"
+  # shellcheck disable=SC2086
+  gem install -N "${INPUT_RUBOCOP_EXTENSION_NAME}" ${RUBOCOP_EXTENSION_VERSION_FLAG}
 done
 
-rubocop "${INPUT_RUBOCOP_FLAGS}" \
+# shellcheck disable=SC2086
+rubocop ${INPUT_RUBOCOP_FLAGS} \
   | reviewdog -f=rubocop \
       -name="${INPUT_TOOL_NAME}" \
       -reporter="${INPUT_REPORTER}" \


### PR DESCRIPTION
This PR addresses https://github.com/reviewdog/action-rubocop/issues/17

## Description of change

We'd been running this action for some time using a [custom gem](https://docs.rubocop.org/rubocop/configuration.html#inheriting-configuration-from-a-dependency-gem) for rubcop's config.  We passed this gem name into the action using the `rubocop_extensions` parameter as it pre-loaded every gem passed in here.  Alas, the change to add the parsing of the version from the gemfile stopped loading extensions unless they were prefixed with `rubocop-`.  I've therefore changed this to allow reading extensions with any name, not just beginning with rubocop.

While making this change, I found and fixed a few more issues:

- Switched the pattern match to use a simple awk to break up the gem:version patterns for the basic extension pattern match.  This was much easier (for me!) than trying to concoct a regex here for every possible combination of extension names.
- Handle extensions that have no version number.  The previous change always assumed every extension had a version number and failed if it didn't
- Ran and addressed all [shellcheck](https://www.shellcheck.net/) reported problems
  - in sh, [[ ]] is undefined
  - various quoting issues
  - don't use cat when piping to grep
- This action runs under Alpine Linux, whose version of grep does not support the `-P` flag (PCRE regexes).  I had to install the `pcre-tools` module in the Dockerfile and then use `pcregrep` to match the patterns in the lockfile

## Testing Performed

I tested in a few ways:

### Non-rubocop prefixed extensions / extensions with no version number
Modified my own workflow in a project to pull in the fork of this action using the following config:

```
      - name: rubocop
        uses: rewindio/action-rubocop@hotfix/fix_extension_processing
        with:
          rubocop_version: 0.88
          rubocop_extensions: rubocop-performance:1.5.1 rubocop-minitest rewind-ruby-style
          github_token: ${{ secrets.github_token }}
          filter_mode: file
```

This now works (tests different prefixed extensions and extensions with no version number specified

### Reading rubocop version from gemfile

I tested this locally by making a copy of entryfile.sh and mounting it into a Docker container run locally for this action.  I then set the rubocop_version to `gemfile` and ensured it read it from my Gemfile.lock

### Reading extension version from gemfile

Similarly, I set the version for `rewind-ruby-style` to `gemfile` and ensured it was read from my Gemfile.lock.
