### PR TITLE
Use rubocop defined in a gem

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -40,6 +40,9 @@ inputs:
   workdir:
     description: "The directory from which to look for and run Rubocop. Default '.'"
     default: '.'
+  bundled_rubocop:
+    description: 'Enable if rubocop is bundled within another gem'
+    default: 'false'
 runs:
   using: 'docker'
   image: 'Dockerfile'
@@ -55,6 +58,7 @@ runs:
     - ${{ inputs.fail_on_error }}
     - ${{ inputs.reviewdog_flags }}
     - ${{ inputs.workdir }}
+    - ${{ inputs.bundled_rubocop }}
 branding:
   icon: 'check-circle'
   color: 'red'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -77,6 +77,8 @@ fi
 command="rubocop"
 
 if [ "${INPUT_BUNDLED_RUBOCOP}" = "true" ]; then
+  gem install -N bundler
+  bundle install
   command="bundle exec rubocop"
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -33,47 +33,55 @@ fi
 
 gem install -N rubocop --version "${RUBOCOP_VERSION}"
 
-# Traverse over list of rubocop extensions
-for extension in $INPUT_RUBOCOP_EXTENSIONS; do
-  # grep for name and version
-  INPUT_RUBOCOP_EXTENSION_NAME=$(echo "$extension" |awk 'BEGIN { FS = ":" } ; { print $1 }')
-  INPUT_RUBOCOP_EXTENSION_VERSION=$(echo "$extension" |awk 'BEGIN { FS = ":" } ; { print $2 }')
+if [ "${INPUT_BUNDLED_RUBOCOP}" = "false" ]; then
+  # Traverse over list of rubocop extensions
+  for extension in $INPUT_RUBOCOP_EXTENSIONS; do
+    # grep for name and version
+    INPUT_RUBOCOP_EXTENSION_NAME=$(echo "$extension" |awk 'BEGIN { FS = ":" } ; { print $1 }')
+    INPUT_RUBOCOP_EXTENSION_VERSION=$(echo "$extension" |awk 'BEGIN { FS = ":" } ; { print $2 }')
 
-  # if version is 'gemfile'
-  if [ "${INPUT_RUBOCOP_EXTENSION_VERSION}" = "gemfile" ]; then
-    # if Gemfile.lock is here
-    if [ -f 'Gemfile.lock' ]; then
-      # grep for rubocop extension version
-      RUBOCOP_EXTENSION_GEMFILE_VERSION=$(pcregrep -o "^\s{4}$INPUT_RUBOCOP_EXTENSION_NAME\s\(\K.*(?=\))" Gemfile.lock)
+    # if version is 'gemfile'
+    if [ "${INPUT_RUBOCOP_EXTENSION_VERSION}" = "gemfile" ]; then
+      # if Gemfile.lock is here
+      if [ -f 'Gemfile.lock' ]; then
+        # grep for rubocop extension version
+        RUBOCOP_EXTENSION_GEMFILE_VERSION=$(pcregrep -o "^\s{4}$INPUT_RUBOCOP_EXTENSION_NAME\s\(\K.*(?=\))" Gemfile.lock)
 
-      # if rubocop extension version found, then pass it to the gem install
-      # left it empty otherwise, so no version will be passed
-      if [ -n "$RUBOCOP_EXTENSION_GEMFILE_VERSION" ]; then
-        RUBOCOP_EXTENSION_VERSION=$RUBOCOP_EXTENSION_GEMFILE_VERSION
+        # if rubocop extension version found, then pass it to the gem install
+        # left it empty otherwise, so no version will be passed
+        if [ -n "$RUBOCOP_EXTENSION_GEMFILE_VERSION" ]; then
+          RUBOCOP_EXTENSION_VERSION=$RUBOCOP_EXTENSION_GEMFILE_VERSION
+          else
+            printf "Cannot get the rubocop extension version from Gemfile.lock. The latest version will be installed."
+        fi
         else
-          printf "Cannot get the rubocop extension version from Gemfile.lock. The latest version will be installed."
+          printf 'Gemfile.lock not found. The latest version will be installed.'
       fi
-      else
-        printf 'Gemfile.lock not found. The latest version will be installed.'
+    else
+      # set desired rubocop extension version
+      RUBOCOP_EXTENSION_VERSION=$INPUT_RUBOCOP_EXTENSION_VERSION
     fi
-  else
-    # set desired rubocop extension version
-    RUBOCOP_EXTENSION_VERSION=$INPUT_RUBOCOP_EXTENSION_VERSION
-  fi
 
-  # Handle extensions with no version qualifier
-  if [ -z "${RUBOCOP_EXTENSION_VERSION}" ]; then
-    unset RUBOCOP_EXTENSION_VERSION_FLAG
-  else
-    RUBOCOP_EXTENSION_VERSION_FLAG="--version ${RUBOCOP_EXTENSION_VERSION}"
-  fi
+    # Handle extensions with no version qualifier
+    if [ -z "${RUBOCOP_EXTENSION_VERSION}" ]; then
+      unset RUBOCOP_EXTENSION_VERSION_FLAG
+    else
+      RUBOCOP_EXTENSION_VERSION_FLAG="--version ${RUBOCOP_EXTENSION_VERSION}"
+    fi
 
-  # shellcheck disable=SC2086
-  gem install -N "${INPUT_RUBOCOP_EXTENSION_NAME}" ${RUBOCOP_EXTENSION_VERSION_FLAG}
-done
+    # shellcheck disable=SC2086
+    gem install -N "${INPUT_RUBOCOP_EXTENSION_NAME}" ${RUBOCOP_EXTENSION_VERSION_FLAG}
+  done
+fi
+
+command="rubocop"
+
+if [ "${INPUT_BUNDLED_RUBOCOP}" = "true" ]; then
+  command="bundle exec rubocop"
+fi
 
 # shellcheck disable=SC2086
-rubocop ${INPUT_RUBOCOP_FLAGS} \
+$command ${INPUT_RUBOCOP_FLAGS} \
   | reviewdog -f=rubocop \
       -name="${INPUT_TOOL_NAME}" \
       -reporter="${INPUT_REPORTER}" \


### PR DESCRIPTION
This PR allows us to use rubocop with rules and rubocop extensions defined in another gem.

```.rubycop.yml
# .rubycop.yml
inherit_gem:
  other_gem: .rubocop.yml
```

```Ruby
# Gemfile
gem 'other_gem'
```

```Gemspec
# other_gem.gemspec
spec.add_runtime_dependency "rubocop-gitlab-security"
spec.add_runtime_dependency "rubocop-minitest"
spec.add_runtime_dependency "rubocop-performance"
```
