### PR TITLE
Fail fast when an error happens in script.sh

### DIFF
--- a/script.sh
+++ b/script.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -e
 version() {
   if [ -n "$1" ]; then
     echo "-v $1"


### PR DESCRIPTION
This is a suggestion that is related to https://github.com/reviewdog/action-rubocop/issues/34. 

As like the problem reported in #34, when gem installation or rubocop command or any command in the shell script fails, I think also the script should fail immediately and tell the failure through an exit status.

On my end, although the problem described in #34 had been happening in a certain term our team wasn't able to find it keep failing due to the status kept green check mark.

![image](https://user-images.githubusercontent.com/1811616/110071217-fefa3200-7dbe-11eb-9832-cfac134886cc.png)

## References

ref https://stackoverflow.com/questions/19622198/what-does-set-e-mean-in-a-bash-script