### PR TITLE
Fix ignored workdir

### DIFF
--- a/script.sh
+++ b/script.sh
@@ -5,7 +5,7 @@ version() {
   fi
 }
 
-cd "${GITHUB_WORKSPACE}" || exit
+cd "${GITHUB_WORKSPACE}/${INPUT_WORKDIR}" || exit
 export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
 
 TEMP_PATH="$(mktemp -d)"


### PR DESCRIPTION
The `workdir` input is currently never used.