### PR TITLE
Fix depup

### DIFF
--- a/.github/workflows/depup.yml
+++ b/.github/workflows/depup.yml
@@ -18,7 +18,7 @@ jobs:
           repo: reviewdog/reviewdog
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v2
+        uses: peter-evans/create-pull-request@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           title: "chore(deps): update reviewdog to ${{ steps.depup.outputs.latest }}"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1811616/112708170-de238900-8ef3-11eb-896f-2adb9fa2ca22.png)

`depup` workflow has been failing due to the following error.

ref: https://github.com/reviewdog/action-rubocop/runs/2202571963?check_suite_focus=true

```
Error: Unable to process command '::set-env name=pythonLocation::/opt/hostedtoolcache/Python/3.9.2/x64' successfully.
Error: The `set-env` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
Error: Unable to process command '::add-path::/opt/hostedtoolcache/Python/3.9.2/x64' successfully.
Error: The `add-path` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
Error: Unable to process command '::add-path::/opt/hostedtoolcache/Python/3.9.2/x64/bin' successfully.
Error: The `add-path` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
```

This error occurs with `peter-evans/create-pull-request@v2` that uses the deprecated `set-env` in its process.
ref: https://github.com/peter-evans/create-pull-request/issues/632

So it should be upgraded to v3 to avoid failure.
upgrade guide: https://github.com/peter-evans/create-pull-request/blob/5666cd8fe97f4f0781e50095d9e853a7a97e238b/docs/updating.md