### PR TITLE
Skip global offenses to avoid "undefined method `begin'"

### DIFF
--- a/rdjson_formatter/rdjson_formatter.rb
+++ b/rdjson_formatter/rdjson_formatter.rb
@@ -16,6 +16,8 @@ class RdjsonFormatter < RuboCop::Formatter::BaseFormatter
 
   def file_finished(file, offenses)
     offenses.each do |offense|
+      next if offense.location == RuboCop::Cop::Offense::NO_LOCATION
+
       @rdjson[:diagnostics] << build_diagnostic(file, offense)
     end
   end


### PR DESCRIPTION
## Issue

Fixes https://github.com/reviewdog/action-rubocop/issues/55

## Change

As described https://github.com/reviewdog/action-rubocop/issues/55#issuecomment-971470429, rdjson_formatter fails to build diagnostic when a given offense has `NO_LOCATION`.

`NO_LOCATION` indicates a global offense that has no particular location. For example, an empty file is applicable. Since no correction can be applied to global offenses, it should skip reporting (that's how `action-rubodop@v1` works).

https://github.com/rubocop/rubocop/blob/de4f7cdd266999bf2cfbe78bd7fd8a0d4580863d/lib/rubocop/cop/base.rb#L105-L112