### PR TITLE
docs(README.md): Add github-check option to reporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ It's same as `-level` flag of reviewdog.
 
 ### `reporter`
 
-Optional. Reporter of reviewdog command [`github-pr-check`, `github-pr-review`].
+Optional. Reporter of reviewdog command [`github-pr-check`, `github-check`, `github-pr-review`].
 The default is `github-pr-check`.
 
 ### `filter_mode`

--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,7 @@ inputs:
     default: 'error'
   reporter:
     description: |
-      Reporter of reviewdog command [github-pr-check,github-pr-review].
+      Reporter of reviewdog command [github-pr-check,github-check,github-pr-review].
       Default is github-pr-check.
     default: 'github-pr-check'
   filter_mode:


### PR DESCRIPTION
Error `reviewdog: this is not PullRequest build` happened, and I solved it by referring to https://github.com/reviewdog/reviewdog/issues/889#issuecomment-817646479.
>I've revisited it just now and using the github-check reporter instead of github-pr-review/github-pr-check seems to address the issue:
https://github.com/reviewdog/reviewdog#reporter-github-checks--reportergithub-check