### PR TITLE
Use `correctable?` for branching build_suggestions

### DIFF
--- a/rdjson_formatter/rdjson_formatter.rb
+++ b/rdjson_formatter/rdjson_formatter.rb
@@ -56,7 +56,7 @@ class RdjsonFormatter < RuboCop::Formatter::BaseFormatter
       original_output: offense.to_s
     }
 
-    diagnostic[:suggestions] = build_suggestions(offense) if offense.corrector
+    diagnostic[:suggestions] = build_suggestions(offense) if offense.correctable?
 
     diagnostic
   end


### PR DESCRIPTION
fixed #68

ref: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Offense#correctable%3F-instance_method