### PR TITLE
README: Add "permissions" field to example of usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,9 @@ You can create [RuboCop Configuration](https://docs.rubocop.org/rubocop/configur
 ```yml
 name: reviewdog
 on: [pull_request]
+permissions:
+  contents: read
+  pull-requests: write
 jobs:
   rubocop:
     name: runner / rubocop


### PR DESCRIPTION
To request explicitly the minimum required permissions for this action
to GitHub Actions, this adds "permissions" field to the example of
job definition.

This does not request users to make their default setting permisssive.