### PR TITLE
Avoid nil pointer exception with correctable offense without corrector

### DIFF
--- a/rdjson_formatter/rdjson_formatter.rb
+++ b/rdjson_formatter/rdjson_formatter.rb
@@ -56,7 +56,7 @@ class RdjsonFormatter < RuboCop::Formatter::BaseFormatter
       original_output: offense.to_s
     }
 
-    diagnostic[:suggestions] = build_suggestions(offense) if offense.correctable?
+    diagnostic[:suggestions] = build_suggestions(offense) if offense.correctable? && offense.corrector
 
     diagnostic
   end


### PR DESCRIPTION
This can happen when the offense is in rubocop cache or in parallel mode.

This is probably a bug in rubocop, but missing a correction is better than crashing :)