### PR TITLE
Change `original_output` in `RdjsonFormatter`, adding file

### DIFF
--- a/rdjson_formatter/rdjson_formatter.rb
+++ b/rdjson_formatter/rdjson_formatter.rb
@@ -3,6 +3,8 @@
 # https://docs.rubocop.org/rubocop/formatters.html
 # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
 class RdjsonFormatter < RuboCop::Formatter::BaseFormatter
+  include RuboCop::PathUtil
+
   def started(_target_files)
     @rdjson = {
       source: {
@@ -53,7 +55,7 @@ class RdjsonFormatter < RuboCop::Formatter::BaseFormatter
       code: {
         value: code
       },
-      original_output: offense.to_s
+      original_output: build_original_output(file, offense)
     }
 
     diagnostic[:suggestions] = build_suggestions(offense) if offense.correctable? && offense.corrector
@@ -118,6 +120,20 @@ class RdjsonFormatter < RuboCop::Formatter::BaseFormatter
     rescue ArgumentError
       path
     end
+  end
+
+  # @param [String] file
+  # @param [RuboCop::Cop::Offense] offense
+  # @return [String]
+  def build_original_output(file, offense)
+    format(
+      '%<path>s:%<line>d:%<column>d: %<severity>s: %<message>s',
+      path: smart_path(file),
+      line: offense.line,
+      column: offense.real_column,
+      severity: offense.severity.code,
+      message: offense.message
+    )
   end
 end
 # rubocop:enable Metrics/AbcSize, Metrics/MethodLength

--- a/test/rdjson_formatter/testdata/result.ok
+++ b/test/rdjson_formatter/testdata/result.ok
@@ -23,7 +23,7 @@
       "code": {
         "value": "Style/FrozenStringLiteralComment"
       },
-      "original_output": "C:  1:  1: Style/FrozenStringLiteralComment: Missing frozen string literal comment.",
+      "original_output": "test/rdjson_formatter/testdata/correctable_offenses.rb:1:1: C: Style/FrozenStringLiteralComment: Missing frozen string literal comment.",
       "suggestions": [
         {
           "range": {
@@ -59,7 +59,7 @@
       "code": {
         "value": "Layout/SpaceAfterComma"
       },
-      "original_output": "C:  1: 12: Layout/SpaceAfterComma: Space missing after comma.",
+      "original_output": "test/rdjson_formatter/testdata/correctable_offenses.rb:1:12: C: Layout/SpaceAfterComma: Space missing after comma.",
       "suggestions": [
         {
           "range": {
@@ -95,7 +95,7 @@
       "code": {
         "value": "Layout/ExtraSpacing"
       },
-      "original_output": "C:  2:  4: Layout/ExtraSpacing: Unnecessary spacing detected.",
+      "original_output": "test/rdjson_formatter/testdata/correctable_offenses.rb:2:4: C: Layout/ExtraSpacing: Unnecessary spacing detected.",
       "suggestions": [
         {
           "range": {
@@ -131,7 +131,7 @@
       "code": {
         "value": "Layout/SpaceAroundOperators"
       },
-      "original_output": "C:  2: 13: Layout/SpaceAroundOperators: Surrounding space missing for operator `+`.",
+      "original_output": "test/rdjson_formatter/testdata/correctable_offenses.rb:2:13: C: Layout/SpaceAroundOperators: Surrounding space missing for operator `+`.",
       "suggestions": [
         {
           "range": {
@@ -167,7 +167,7 @@
       "code": {
         "value": "Layout/ExtraSpacing"
       },
-      "original_output": "C:  2: 14: Layout/ExtraSpacing: Unnecessary spacing detected.",
+      "original_output": "test/rdjson_formatter/testdata/correctable_offenses.rb:2:14: C: Layout/ExtraSpacing: Unnecessary spacing detected.",
       "suggestions": [
         {
           "range": {
@@ -203,7 +203,7 @@
       "code": {
         "value": "Style/Semicolon"
       },
-      "original_output": "C:  2: 20: Style/Semicolon: Do not use semicolons to terminate expressions.",
+      "original_output": "test/rdjson_formatter/testdata/correctable_offenses.rb:2:20: C: Style/Semicolon: Do not use semicolons to terminate expressions.",
       "suggestions": [
         {
           "range": {
@@ -239,7 +239,7 @@
       "code": {
         "value": "Style/RedundantReturn"
       },
-      "original_output": "C:  3:  3: Style/RedundantReturn: Redundant `return` detected.",
+      "original_output": "test/rdjson_formatter/testdata/correctable_offenses.rb:3:3: C: Style/RedundantReturn: Redundant `return` detected.",
       "suggestions": [
         {
           "range": {
@@ -275,7 +275,7 @@
       "code": {
         "value": "Layout/ExtraSpacing"
       },
-      "original_output": "C:  3:  9: Layout/ExtraSpacing: Unnecessary spacing detected.",
+      "original_output": "test/rdjson_formatter/testdata/correctable_offenses.rb:3:9: C: Layout/ExtraSpacing: Unnecessary spacing detected.",
       "suggestions": [
         {
           "range": {
@@ -311,7 +311,7 @@
       "code": {
         "value": "Naming/MethodParameterName"
       },
-      "original_output": "C:  4: 15: Naming/MethodParameterName: Method parameter must be at least 3 characters long."
+      "original_output": "test/rdjson_formatter/testdata/not_correctable_offenses.rb:4:15: C: Naming/MethodParameterName: Method parameter must be at least 3 characters long."
     },
     {
       "message": "Method parameter must be at least 3 characters long.",
@@ -332,7 +332,7 @@
       "code": {
         "value": "Naming/MethodParameterName"
       },
-      "original_output": "C:  4: 18: Naming/MethodParameterName: Method parameter must be at least 3 characters long."
+      "original_output": "test/rdjson_formatter/testdata/not_correctable_offenses.rb:4:18: C: Naming/MethodParameterName: Method parameter must be at least 3 characters long."
     },
     {
       "message": "Useless assignment to variable - `c`.",
@@ -353,7 +353,7 @@
       "code": {
         "value": "Lint/UselessAssignment"
       },
-      "original_output": "W:  5:  5: Lint/UselessAssignment: Useless assignment to variable - `c`."
+      "original_output": "test/rdjson_formatter/testdata/not_correctable_offenses.rb:5:5: W: Lint/UselessAssignment: Useless assignment to variable - `c`."
     }
   ]
 }


### PR DESCRIPTION
`original_output` field in `RdjsonFormatter` is printed by reviewdog on running the action with github-pr-review reporter.

Before, it did not contain file, thus messages were not fully informative.
Example https://github.com/Slike9/GitHub-Actions-PlayGround/actions/runs/3887880250/jobs/6634622915#step:5:61
```
C:  1:  1: Style/FrozenStringLiteralComment: Missing frozen string literal comment.
```

This PR fixes the field, adding file.
Example https://github.com/Slike9/GitHub-Actions-PlayGround/actions/runs/3887873154/jobs/6634608438#step:5:61
```
index.rb:1:1: C: Style/FrozenStringLiteralComment: Missing frozen string literal comment.
```
This format is borrowed from [ClangStyleFormatter](https://github.com/rubocop/rubocop/blob/8698ae90837424747e9ce00a7596346ae2509ed1/lib/rubocop/formatter/clang_style_formatter.rb#L18) formatter (default formatter, `ProgressFormatter`, inherits it). 