### PR TITLE
Don't let stderr impact result parsing

### DIFF
--- a/script.sh
+++ b/script.sh
@@ -93,6 +93,7 @@ fi
 echo '::group:: Running rubocop with reviewdog 🐶 ...'
 # shellcheck disable=SC2086
 ${BUNDLE_EXEC}rubocop ${INPUT_RUBOCOP_FLAGS} --require ${GITHUB_ACTION_PATH}/rdjson_formatter/rdjson_formatter.rb --format RdjsonFormatter \
+  2> /dev/null
   | reviewdog -f=rdjson \
       -name="${INPUT_TOOL_NAME}" \
       -reporter="${INPUT_REPORTER}" \

--- a/script.sh
+++ b/script.sh
@@ -93,7 +93,7 @@ fi
 echo '::group:: Running rubocop with reviewdog 🐶 ...'
 # shellcheck disable=SC2086
 ${BUNDLE_EXEC}rubocop ${INPUT_RUBOCOP_FLAGS} --require ${GITHUB_ACTION_PATH}/rdjson_formatter/rdjson_formatter.rb --format RdjsonFormatter \
-  2> /dev/null
+  2> /dev/null \
   | reviewdog -f=rdjson \
       -name="${INPUT_TOOL_NAME}" \
       -reporter="${INPUT_REPORTER}" \


### PR DESCRIPTION
When using some ruby versions, `parser` often outputs a warning to stderr: https://github.com/whitequark/parser/blob/c44b23d54f9074d0ea5631af8bfd602fe26153fc/lib/parser/current.rb#L5

This rarely has any impact, but it's still there, and (while it's hard to confirm) I believe that's still getting piped through to reviewdog. Since this gets inserted before the JSON output, the result is an error: `reviewdog: failed to unmarshal rdjson (DiagnosticResult): proto: syntax error (line 1:1): unexpected token `

To fix this, we add a pipe of stderr, where the warning comes in, and ignore it. This way, the JSON parsing runs only on valid stdout.