### PR TITLE
Fix relative_path_from error with old ruby 2.5.x

### DIFF
--- a/rdjson_formatter/rdjson_formatter.rb
+++ b/rdjson_formatter/rdjson_formatter.rb
@@ -136,7 +136,7 @@ class RdjsonFormatter < RuboCop::Formatter::BaseFormatter
     base_path = Dir.pwd
 
     begin
-      Pathname.new(File.expand_path(path)).relative_path_from(base_path).to_s
+      Pathname.new(File.expand_path(path)).relative_path_from(Pathname.new(base_path)).to_s
     rescue ArgumentError
       path
     end


### PR DESCRIPTION
In ruby 2.6 it's already solved. in stdlib

Original error callstack: 
```
undefined method `cleanpath' for "/home/runner/work/sales/sales":String
  /opt/hostedtoolcache/Ruby/2.5.9/x64/lib/ruby/2.5.0/pathname.rb:508:in `relative_path_from'
  /home/runner/work/_actions/reviewdog/action-rubocop/v2.11/rdjson_formatter/rdjson_formatter.rb:139:in `convert_path'
  /home/runner/work/_actions/reviewdog/action-rubocop/v2.11/rdjson_formatter/rdjson_formatter.rb:62:in `build_diagnostic'
  /home/runner/work/_actions/reviewdog/action-rubocop/v2.11/rdjson_formatter/rdjson_formatter.rb:23:in `block in file_finished'
  /home/runner/work/_actions/reviewdog/action-rubocop/v2.11/rdjson_formatter/rdjson_formatter.rb:20:in `each'
  /home/runner/work/_actions/reviewdog/action-rubocop/v2.11/rdjson_formatter/rdjson_formatter.rb:20:in `file_finished'
  /home/runner/work/sales/sales/vendor/bundle/ruby/2.5.0/gems/rubocop-1.28.0/lib/rubocop/formatter/formatter_set.rb:50:in `block in file_finished'
  /home/runner/work/sales/sales/vendor/bundle/ruby/2.5.0/gems/rubocop-1.28.0/lib/rubocop/formatter/formatter_set.rb:50:in `each'
  /home/runner/work/sales/sales/vendor/bundle/ruby/2.5.0/gems/rubocop-1.28.0/lib/rubocop/formatter/formatter_set.rb:50:in `file_finished'
  /home/runner/work/sales/sales/vendor/bundle/ruby/2.5.0/gems/rubocop-1.28.0/lib/rubocop/runner.rb:211:in `file_finished'
  /home/runner/work/sales/sales/vendor/bundle/ruby/2.5.0/gems/rubocop-1.28.0/lib/rubocop/runner.rb:125:in `process_file'
  /home/runner/work/sales/sales/vendor/bundle/ruby/2.5.0/gems/rubocop-1.28.0/lib/rubocop/runner.rb:101:in `block in each_inspected_file'
  /home/runner/work/sales/sales/vendor/bundle/ruby/2.5.0/gems/rubocop-1.28.0/lib/rubocop/runner.rb:100:in `each'
  /home/runner/work/sales/sales/vendor/bundle/ruby/2.5.0/gems/rubocop-1.28.0/lib/rubocop/runner.rb:100:in `reduce'
  /home/runner/work/sales/sales/vendor/bundle/ruby/2.5.0/gems/rubocop-1.28.0/lib/rubocop/runner.rb:100:in `each_inspected_file'
  /home/runner/work/sales/sales/vendor/bundle/ruby/2.5.0/gems/rubocop-1.28.0/lib/rubocop/runner.rb:86:in `inspect_files'
  /home/runner/work/sales/sales/vendor/bundle/ruby/2.5.0/gems/rubocop-1.28.0/lib/rubocop/runner.rb:[47](https://github.com/customink/sales/actions/runs/8828264908/job/24236915691?pr=804#step:4:50):in `run'
  /home/runner/work/sales/sales/vendor/bundle/ruby/2.5.0/gems/rubocop-1.28.0/lib/rubocop/cli/command/execute_runner.rb:26:in `block in execute_runner'
  /home/runner/work/sales/sales/vendor/bundle/ruby/2.5.0/gems/rubocop-1.28.0/lib/rubocop/cli/command/execute_runner.rb:52:in `with_redirect'
  /home/runner/work/sales/sales/vendor/bundle/ruby/2.5.0/gems/rubocop-1.28.0/lib/rubocop/cli/command/execute_runner.rb:25:in `execute_runner'
  /home/runner/work/sales/sales/vendor/bundle/ruby/2.5.0/gems/rubocop-1.28.0/lib/rubocop/cli/command/execute_runner.rb:17:in `run'
  /home/runner/work/sales/sales/vendor/bundle/ruby/2.5.0/gems/rubocop-1.28.0/lib/rubocop/cli/command.rb:11:in `run'
  /home/runner/work/sales/sales/vendor/bundle/ruby/2.5.0/gems/rubocop-1.28.0/lib/rubocop/cli/environment.rb:18:in `run'
  /home/runner/work/sales/sales/vendor/bundle/ruby/2.5.0/gems/rubocop-1.28.0/lib/rubocop/cli.rb:71:in `run_command'
  /home/runner/work/sales/sales/vendor/bundle/ruby/2.5.0/gems/rubocop-1.28.0/lib/rubocop/cli.rb:78:in `execute_runners'
  /home/runner/work/sales/sales/vendor/bundle/ruby/2.5.0/gems/rubocop-1.28.0/lib/rubocop/cli.rb:47:in `run'
  /home/runner/work/sales/sales/vendor/bundle/ruby/2.5.0/gems/rubocop-1.28.0/exe/rubocop:12:in `block in <top (required)>'
  /opt/hostedtoolcache/Ruby/2.5.9/x64/lib/ruby/2.5.0/benchmark.rb:308:in `realtime'
  /home/runner/work/sales/sales/vendor/bundle/ruby/2.5.0/gems/rubocop-1.28.0/exe/rubocop:12:in `<top (required)>'
  /home/runner/work/sales/sales/vendor/bundle/ruby/2.5.0/bin/rubocop:23:in `load'
  /home/runner/work/sales/sales/vendor/bundle/ruby/2.5.0/bin/rubocop:23:in `<top (required)>'
  /opt/hostedtoolcache/Ruby/2.5.9/x64/lib/ruby/gems/2.5.0/gems/bundler-2.3.26/lib/bundler/cli/exec.rb:58:in `load'
  /opt/hostedtoolcache/Ruby/2.5.9/x64/lib/ruby/gems/2.5.0/gems/bundler-2.3.26/lib/bundler/cli/exec.rb:58:in `kernel_load'
  /opt/hostedtoolcache/Ruby/2.5.9/x64/lib/ruby/gems/2.5.0/gems/bundler-2.3.26/lib/bundler/cli/exec.rb:23:in `run'
  /opt/hostedtoolcache/Ruby/2.5.9/x64/lib/ruby/gems/2.5.0/gems/bundler-2.3.26/lib/bundler/cli.rb:[48](https://github.com/customink/sales/actions/runs/8828264908/job/24236915691?pr=804#step:4:51)6:in `exec'
  /opt/hostedtoolcache/Ruby/2.5.9/x64/lib/ruby/gems/2.5.0/gems/bundler-2.3.26/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
  /opt/hostedtoolcache/Ruby/2.5.9/x64/lib/ruby/gems/2.5.0/gems/bundler-2.3.26/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
  /opt/hostedtoolcache/Ruby/2.5.9/x64/lib/ruby/gems/2.5.0/gems/bundler-2.3.26/lib/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
  /opt/hostedtoolcache/Ruby/2.5.9/x64/lib/ruby/gems/2.5.0/gems/bundler-2.3.26/lib/bundler/cli.rb:31:in `dispatch'
  /opt/hostedtoolcache/Ruby/2.5.9/x64/lib/ruby/gems/2.5.0/gems/bundler-2.3.26/lib/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
  /opt/hostedtoolcache/Ruby/2.5.9/x64/lib/ruby/gems/2.5.0/gems/bundler-2.3.26/lib/bundler/cli.rb:25:in `start'
  /opt/hostedtoolcache/Ruby/2.5.9/x64/lib/ruby/gems/2.5.0/gems/bundler-2.3.26/exe/bundle:48:in `block in <top (required)>'
  /opt/hostedtoolcache/Ruby/2.5.9/x64/lib/ruby/gems/2.5.0/gems/bundler-2.3.26/lib/bundler/friendly_errors.rb:120:in `with_friendly_errors'
  /opt/hostedtoolcache/Ruby/2.5.9/x64/lib/ruby/gems/2.5.0/gems/bundler-2.3.26/exe/bundle:36:in `<top (required)>'
  /opt/hostedtoolcache/Ruby/2.5.9/x64/bin/bundle:23:in `load'
  /opt/hostedtoolcache/Ruby/2.5.9/x64/bin/bundle:23:in `<main>'
```