### PR TITLE
add only_changed input to run rubocop only against changed files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ jobs:
       BUNDLE_GEMFILE: ${{ github.workspace }}/test/using_bundler/Gemfile
     steps:
       - uses: actions/checkout@v4
+      - name: Fetch head commit of base branch
+        run: git fetch --depth 1 origin ${{ github.event.pull_request.base.sha }}
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,6 @@ jobs:
       BUNDLE_GEMFILE: ${{ github.workspace }}/test/using_bundler/Gemfile
     steps:
       - uses: actions/checkout@v4
-      - name: Fetch head commit of base branch
-        run: git fetch --depth 1 origin ${{ github.event.pull_request.base.sha }}
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,6 @@ name: CI
 on: [pull_request]
 jobs:
   test-skip-install-and-use-bundler:
-    name: runner / rubocop
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,3 +21,55 @@ jobs:
           skip_install: 'true'
           use_bundler: 'true'
       - run: test "$(bundle exec rubocop --version)" == "1.18.1"
+  test-only_changed:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    env:
+      INPUT_ONLY_CHANGED: 'true'
+    steps:
+      - uses: actions/checkout@v4
+      - name: setup
+        run: |
+          git config user.email "workflow@github.com"
+          git config user.name "I am an automated workflow"
+      - name: Check when there are relevant files
+        run: |
+          git checkout ${{ github.sha }}
+          rm -f test/only_changed/reviewdog-was-called
+
+          cp test/only_changed/few_relevant/files/* .
+          git add *
+          git commit -m auto
+
+          export PATH=test/only_changed/few_relevant/mock_bins:test/only_changed/shared_mock_bins:$PATH
+          BASE_REF=$(git rev-parse HEAD~) HEAD_REF=$(git rev-parse HEAD) ./script.sh
+
+          [ -f test/only_changed/reviewdog-was-called ]
+      - name: Check when there are no relevant files
+        run: |
+          git checkout ${{ github.sha }}
+          rm -f test/only_changed/reviewdog-was-called
+
+          cp test/only_changed/nothing_relevant/files/* .
+          git add *
+          git commit -m auto
+
+          export PATH=test/only_changed/nothing_relevant/mock_bins:test/only_changed/shared_mock_bins:$PATH
+          BASE_REF=$(git rev-parse HEAD~) HEAD_REF=$(git rev-parse HEAD) ./script.sh
+
+          [ ! -f test/only_changed/reviewdog-was-called ]
+      - name: Check when there are too many relevant files
+        run: |
+          git checkout ${{ github.sha }}
+          rm -f test/only_changed/reviewdog-was-called
+
+          touch a{00..100}.rb
+          git add *
+          git commit -m auto
+
+          export PATH=test/only_changed/too_many_relevant/mock_bins:test/only_changed/shared_mock_bins:$PATH
+          BASE_REF=$(git rev-parse HEAD~) HEAD_REF=$(git rev-parse HEAD) ./script.sh
+
+          [ -f test/only_changed/reviewdog-was-called ]

--- a/README.md
+++ b/README.md
@@ -47,6 +47,11 @@ Default is `added`.
 Optional. Report level for reviewdog [`info`, `warning`, `error`].
 It's same as `-level` flag of reviewdog.
 
+### `only_changed`
+
+Optional. Run Rubocop only on changed (and added) files, for speedup [`true`, `false`].
+Default: `false`.
+
 ### `reporter`
 
 Optional. Reporter of reviewdog command [`github-pr-check`, `github-check`, `github-pr-review`].

--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ It's same as `-level` flag of reviewdog.
 Optional. Run Rubocop only on changed (and added) files, for speedup [`true`, `false`].
 Default: `false`.
 
+Will fetch the tip of the base branch with depth 1 from remote origin if it is not available.
+If you use different remote name or customize the checkout otherwise, make the tip of the base branch available before this action
+
 ### `reporter`
 
 Optional. Reporter of reviewdog command [`github-pr-check`, `github-check`, `github-pr-review`].

--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,9 @@ inputs:
   level:
     description: 'Report level for reviewdog [info,warning,error]'
     default: 'error'
+  only_changed:
+    description: "Run Rubocop only on changed (and added) files, for speedup [`true`, `false`]"
+    default: 'false'
   reporter:
     description: |
       Reporter of reviewdog command [github-pr-check,github-check,github-pr-review].
@@ -61,6 +64,7 @@ runs:
         INPUT_FILTER_MODE: ${{ inputs.filter_mode }}
         INPUT_GITHUB_TOKEN: ${{ inputs.github_token }}
         INPUT_LEVEL: ${{ inputs.level }}
+        INPUT_ONLY_CHANGED: ${{ inputs.only_changed }}
         INPUT_REPORTER: ${{ inputs.reporter }}
         INPUT_REVIEWDOG_FLAGS: ${{ inputs.reviewdog_flags }}
         INPUT_RUBOCOP_EXTENSIONS: ${{ inputs.rubocop_extensions }}
@@ -70,6 +74,8 @@ runs:
         INPUT_TOOL_NAME: ${{ inputs.tool_name }}
         INPUT_USE_BUNDLER: ${{ inputs.use_bundler }}
         INPUT_WORKDIR: ${{ inputs.workdir }}
+        BASE_REF: ${{ github.event.pull_request.base.sha }}
+        HEAD_REF: ${{ github.sha }}
 branding:
   icon: 'check-circle'
   color: 'red'

--- a/action.yml
+++ b/action.yml
@@ -20,7 +20,10 @@ inputs:
     description: 'Report level for reviewdog [info,warning,error]'
     default: 'error'
   only_changed:
-    description: "Run Rubocop only on changed (and added) files, for speedup [`true`, `false`]"
+    description: |
+      Run Rubocop only on changed (and added) files, for speedup [`true`, `false`].
+      Will fetch the tip of the base branch with depth 1 from remote origin if it is not available.
+      If you use different remote name or customize the checkout otherwise, make the tip of the base branch available before this action.
     default: 'false'
   reporter:
     description: |

--- a/script.sh
+++ b/script.sh
@@ -91,6 +91,11 @@ fi
 if [ "${INPUT_ONLY_CHANGED}" = "true" ]; then
   echo '::group:: Getting changed files list'
 
+  # check if commit is present in repository, otherwise fetch it
+  if ! git cat-file -e "${BASE_REF}"; then
+    git fetch --depth 1 origin "${BASE_REF}"
+  fi
+
   # get intersection of changed files (excluding deleted) with target files for
   # rubocop as an array
   # shellcheck disable=SC2086

--- a/test/only_changed/few_relevant/files/a.rb
+++ b/test/only_changed/few_relevant/files/a.rb
@@ -1,0 +1,1 @@
+puts "Hello, " + "world!"

--- a/test/only_changed/few_relevant/files/a.txt
+++ b/test/only_changed/few_relevant/files/a.txt
@@ -1,0 +1,1 @@
+puts "Hello, " + "world!"

--- a/test/only_changed/few_relevant/mock_bins/rubocop
+++ b/test/only_changed/few_relevant/mock_bins/rubocop
@@ -1,0 +1,18 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+case ARGV
+when %w[
+  --list-target-files
+]
+  puts Dir['**/*.rb']
+when %W[
+  --require #{ENV['GITHUB_ACTION_PATH']}/rdjson_formatter/rdjson_formatter.rb
+  --format RdjsonFormatter
+  --fail-level error
+  a.rb
+]
+  puts 'Mock message for reviewdog'
+else
+  abort "rubocop mock called with unexpected arguments:\n#{ARGV.join("\n")}"
+end

--- a/test/only_changed/nothing_relevant/files/a.txt
+++ b/test/only_changed/nothing_relevant/files/a.txt
@@ -1,0 +1,1 @@
+puts "Hello, " + "world!"

--- a/test/only_changed/nothing_relevant/mock_bins/rubocop
+++ b/test/only_changed/nothing_relevant/mock_bins/rubocop
@@ -1,0 +1,11 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+case ARGV
+when %w[
+  --list-target-files
+]
+  puts Dir['**/*.rb']
+else
+  abort "rubocop mock called with unexpected arguments:\n#{ARGV.join("\n")}"
+end

--- a/test/only_changed/shared_mock_bins/bundle
+++ b/test/only_changed/shared_mock_bins/bundle
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+if [ "$1" = "exec" ]; then
+  shift
+  eval "$@"
+else
+  echo "Only 'exec' command is supported"
+  exit 1
+fi

--- a/test/only_changed/shared_mock_bins/curl
+++ b/test/only_changed/shared_mock_bins/curl
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+arguments="$*"
+
+if [ "$arguments" != "-sfL https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh" ]; then
+  echo "curl mock got unexpected arguments: $arguments"
+  exit 1
+fi

--- a/test/only_changed/shared_mock_bins/reviewdog
+++ b/test/only_changed/shared_mock_bins/reviewdog
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+touch test/only_changed/reviewdog-was-called
+
+read -r input
+
+if [ "$input" != "Mock message for reviewdog" ]; then
+  echo "reviewdog mock got unexpected input: $input"
+  exit 1
+fi

--- a/test/only_changed/too_many_relevant/mock_bins/rubocop
+++ b/test/only_changed/too_many_relevant/mock_bins/rubocop
@@ -1,0 +1,17 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+case ARGV
+when %w[
+  --list-target-files
+]
+  puts Dir['**/*.rb']
+when %W[
+  --require #{ENV['GITHUB_ACTION_PATH']}/rdjson_formatter/rdjson_formatter.rb
+  --format RdjsonFormatter
+  --fail-level error
+]
+  puts 'Mock message for reviewdog'
+else
+  abort "rubocop mock called with unexpected arguments:\n#{ARGV.join("\n")}"
+end


### PR DESCRIPTION
Add an input to limit running rubocop only against files changed in the PR.

Had to switch to bash for process substitution and working with arrays.

Ignore if there are more than 100 changed files. Main reason is to protect from possibly hitting the command line length limit. In reality the command line length limit most probably (depends on OS) allows much higher number of files and if needed can be calculated or provided as one more input.

Fix ci workflow to fetch all commits for pr branch plus head commit of base branch to be able to find changed files.

~Will conflict with #102, I will update whichever is not merged first~