### PR TITLE
Add flag to only execute rubocop on files changed in a PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ jobs:
       BUNDLE_GEMFILE: ${{ github.workspace }}/test/using_bundler/Gemfile
     steps:
       - uses: actions/checkout@v4
+        - name: Fetch head commit of base branch
+          run: git fetch --depth 1 origin ${{ github.event.pull_request.base.sha }}
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.6

--- a/README.md
+++ b/README.md
@@ -47,6 +47,11 @@ Default is `added`.
 Optional. Report level for reviewdog [`info`, `warning`, `error`].
 It's same as `-level` flag of reviewdog.
 
+### `only_changed`
+
+Optional. Run Rubocop only on changed (and added) files, for speedup [`true`, `false`].
+Default: `false`.
+
 ### `reporter`
 
 Optional. Reporter of reviewdog command [`github-pr-check`, `github-check`, `github-pr-review`].

--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,9 @@ inputs:
   level:
     description: 'Report level for reviewdog [info,warning,error]'
     default: 'error'
+  only_changed:
+    description: "Run Rubocop only on changed (and added) files, for speedup [`true`, `false`]"
+    default: 'false'
   reporter:
     description: |
       Reporter of reviewdog command [github-pr-check,github-check,github-pr-review].
@@ -61,6 +64,7 @@ runs:
         INPUT_FILTER_MODE: ${{ inputs.filter_mode }}
         INPUT_GITHUB_TOKEN: ${{ inputs.github_token }}
         INPUT_LEVEL: ${{ inputs.level }}
+        INPUT_ONLY_CHANGED: ${{ inputs.only_changed }}
         INPUT_REPORTER: ${{ inputs.reporter }}
         INPUT_REVIEWDOG_FLAGS: ${{ inputs.reviewdog_flags }}
         INPUT_RUBOCOP_EXTENSIONS: ${{ inputs.rubocop_extensions }}
@@ -70,6 +74,8 @@ runs:
         INPUT_TOOL_NAME: ${{ inputs.tool_name }}
         INPUT_USE_BUNDLER: ${{ inputs.use_bundler }}
         INPUT_WORKDIR: ${{ inputs.workdir }}
+        BASE_REF: ${{ github.event.pull_request.base.sha }}
+        HEAD_REF: ${{ github.event.pull_request.head.sha }}
 branding:
   icon: 'check-circle'
   color: 'red'


### PR DESCRIPTION
Based [reviewdog/rubocop-action PR](https://github.com/reviewdog/action-rubocop/pull/103) on but with a fix included for the HEAD commit SHA