### PR TITLE
Put `${INPUT_RUBOCOP_FLAGS}` at the end of the other flags

### DIFF
--- a/script.sh
+++ b/script.sh
@@ -123,10 +123,10 @@ fi
 echo '::group:: Running rubocop with reviewdog 🐶 ...'
 # shellcheck disable=SC2086
 ${BUNDLE_EXEC}rubocop \
-  ${INPUT_RUBOCOP_FLAGS} \
   --require ${GITHUB_ACTION_PATH}/rdjson_formatter/rdjson_formatter.rb \
   --format RdjsonFormatter \
   --fail-level error \
+  ${INPUT_RUBOCOP_FLAGS} \
   "${CHANGED_FILES[@]}" \
   | reviewdog -f=rdjson \
       -name="${INPUT_TOOL_NAME}" \


### PR DESCRIPTION
Since PR #103 introduced the default --fail-level flag, the severity level has become unchangeable due to this modification.
Ideally, this flag (and others) should be overridable, but the RuboCop command prioritizes the flags that are specified last. This commit moves the user-specified flags to the end of the hard-coded flags, allowing them to be overridden.

rel: https://github.com/reviewdog/action-rubocop/pull/103/files#r1724248253