### PR TITLE
Support offenses with no location

### DIFF
--- a/rdjson_formatter/rdjson_formatter.rb
+++ b/rdjson_formatter/rdjson_formatter.rb
@@ -18,8 +18,6 @@ class RdjsonFormatter < RuboCop::Formatter::BaseFormatter
 
   def file_finished(file, offenses)
     offenses.each do |offense|
-      next if offense.location == RuboCop::Cop::Offense::NO_LOCATION
-
       @rdjson[:diagnostics] << build_diagnostic(file, offense)
     end
 
@@ -59,17 +57,7 @@ class RdjsonFormatter < RuboCop::Formatter::BaseFormatter
     diagnostic = {
       message: message,
       location: {
-        path: convert_path(file),
-        range: {
-          start: {
-            line: offense.location.begin.line,
-            column: offense.location.begin.column + 1
-          },
-          end: {
-            line: offense.location.end.line,
-            column: offense.location.end.column + 1
-          }
-        }
+        path: convert_path(file)
       },
       severity: convert_severity(offense.severity),
       code: {
@@ -77,10 +65,26 @@ class RdjsonFormatter < RuboCop::Formatter::BaseFormatter
       },
       original_output: build_original_output(file, offense)
     }
+    diagnostic[:location][:range] = build_range(offense) if offense.location != RuboCop::Cop::Offense::NO_LOCATION
 
     diagnostic[:suggestions] = build_suggestions(offense) if offense.correctable? && offense.corrector
 
     diagnostic
+  end
+
+  # @param [RuboCop::Cop::Offense] offense
+  # @return [Hash]
+  def build_range(offense)
+    {
+      start: {
+        line: offense.location.begin.line,
+        column: offense.location.begin.column + 1
+      },
+      end: {
+        line: offense.location.end.line,
+        column: offense.location.end.column + 1
+      }
+    }
   end
 
   # @param [RuboCop::Cop::Offense] offense

--- a/test/rdjson_formatter/testdata/result.ok
+++ b/test/rdjson_formatter/testdata/result.ok
@@ -293,6 +293,17 @@
       ]
     },
     {
+      "message": "Empty file detected.",
+      "location": {
+        "path": "test/rdjson_formatter/testdata/global_offenses.rb"
+      },
+      "severity": "WARNING",
+      "code": {
+        "value": "Lint/EmptyFile"
+      },
+      "original_output": "test/rdjson_formatter/testdata/global_offenses.rb:1:1: W: Lint/EmptyFile: Empty file detected."
+    },
+    {
       "message": "Method parameter must be at least 3 characters long.",
       "location": {
         "path": "test/rdjson_formatter/testdata/not_correctable_offenses.rb",


### PR DESCRIPTION
We noticed 2 rubocop offenses were ignored by reviewdog in our code:

* Lint/EmptyFile
* RSpec/SpecFilePathSuffix

These were skipped because they have no location. This meant our pull requests were green but we had some rubocop offenses if we did a full scan on the main branch.

This PR changes the behaviour by not skipping the whole offense, but only the `range` data.

<img width="894" alt="image" src="https://github.com/user-attachments/assets/16e0e0d7-169a-4875-ab7f-d79a2b1c9a61">
