### PR TITLE
Fix suggestions with multiple corrections

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,24 +2,6 @@ AllCops:
   Exclude:
     - 'test/rdjson_formatter/**/*'
     - 'vendor/**/*'
-Lint/DuplicateSetElement: # new in 1.67
-  Enabled: true
-Lint/UnescapedBracketInRegexp: # new in 1.68
-  Enabled: true
-Lint/UselessNumericOperation: # new in 1.66
-  Enabled: true
-Style/AmbiguousEndlessMethodDefinition: # new in 1.68
-  Enabled: true
-Style/BitwisePredicate: # new in 1.68
-  Enabled: true
-Style/CombinableDefined: # new in 1.68
-  Enabled: true
-Style/KeywordArgumentsMerging: # new in 1.68
-  Enabled: true
-Style/RedundantInterpolationUnfreeze: # new in 1.66
-  Enabled: true
-Style/SafeNavigationChainLength: # new in 1.68
-  Enabled: true
 Gemspec/AddRuntimeDependency: # new in 1.65
   Enabled: true
 Gemspec/DeprecatedAttributeAssignment: # new in 1.30

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,24 @@ AllCops:
   Exclude:
     - 'test/rdjson_formatter/**/*'
     - 'vendor/**/*'
+Lint/DuplicateSetElement: # new in 1.67
+  Enabled: true
+Lint/UnescapedBracketInRegexp: # new in 1.68
+  Enabled: true
+Lint/UselessNumericOperation: # new in 1.66
+  Enabled: true
+Style/AmbiguousEndlessMethodDefinition: # new in 1.68
+  Enabled: true
+Style/BitwisePredicate: # new in 1.68
+  Enabled: true
+Style/CombinableDefined: # new in 1.68
+  Enabled: true
+Style/KeywordArgumentsMerging: # new in 1.68
+  Enabled: true
+Style/RedundantInterpolationUnfreeze: # new in 1.66
+  Enabled: true
+Style/SafeNavigationChainLength: # new in 1.68
+  Enabled: true
 Gemspec/AddRuntimeDependency: # new in 1.65
   Enabled: true
 Gemspec/DeprecatedAttributeAssignment: # new in 1.30

--- a/rdjson_formatter/rdjson_formatter.rb
+++ b/rdjson_formatter/rdjson_formatter.rb
@@ -114,7 +114,7 @@ class RdjsonFormatter < RuboCop::Formatter::BaseFormatter
   def build_corrected_text(corrections, source_buffer, merged_range)
     current_pos = merged_range.begin_pos
     corrected_text = ''
-    
+
     corrections.sort_by { |range, _| range.begin_pos }.each do |range, replacement_text|
       next if range.end_pos < merged_range.begin_pos || range.begin_pos > merged_range.end_pos
 

--- a/rdjson_formatter/rdjson_formatter.rb
+++ b/rdjson_formatter/rdjson_formatter.rb
@@ -90,23 +90,44 @@ class RdjsonFormatter < RuboCop::Formatter::BaseFormatter
   # @param [RuboCop::Cop::Offense] offense
   # @return [Array{Hash}]
   def build_suggestions(offense)
-    range, text = offense.corrector.as_replacements[0]
+    return [] unless offense.correctable? && offense.corrector
 
-    [
-      {
-        range: {
-          start: {
-            line: range.begin.line,
-            column: range.begin.column + 1 # rubocop is 0-origin, reviewdog is 1-origin
-          },
-          end: {
-            line: range.end.line,
-            column: range.end.column + 1
-          }
+    source_buffer = offense.location.source_buffer
+    corrections = offense.corrector.as_replacements
+    return [] if corrections.empty?
+
+    min_begin_pos = corrections.map { |range, _| range.begin_pos }.min
+    max_end_pos = corrections.map { |range, _| range.end_pos }.max
+    merged_range = Parser::Source::Range.new(source_buffer, min_begin_pos, max_end_pos)
+
+    corrected_text = ''
+    current_pos = min_begin_pos
+
+    sorted_corrections = corrections.sort_by { |range, _| range.begin_pos }
+
+    sorted_corrections.each do |range, replacement_text|
+      next if range.end_pos <= min_begin_pos || range.begin_pos >= max_end_pos
+
+      corrected_text += source_buffer.source[current_pos...range.begin_pos] if current_pos < range.begin_pos
+      corrected_text += replacement_text
+      current_pos = range.end_pos
+    end
+
+    corrected_text += source_buffer.source[current_pos...max_end_pos] if current_pos < max_end_pos
+
+    [{
+      range: {
+        start: {
+          line: merged_range.line,
+          column: merged_range.column + 1 # rubocop is 0-origin, reviewdog is 1-origin
         },
-        text: text
-      }
-    ]
+        end: {
+          line: merged_range.last_line,
+          column: merged_range.last_column + 1
+        }
+      },
+      text: corrected_text
+    }]
   end
 
   # https://github.com/reviewdog/reviewdog/blob/1d8f6d6897dcfa67c33a2ccdc2ea23a8cca96c8c/proto/rdf/reviewdog.proto

--- a/rdjson_formatter/rdjson_formatter.rb
+++ b/rdjson_formatter/rdjson_formatter.rb
@@ -105,12 +105,19 @@ class RdjsonFormatter < RuboCop::Formatter::BaseFormatter
     }]
   end
 
+  # @param [Array{Array}] corrections
+  # @param [Parser::Source::Buffer] source_buffer
+  # @return [Parser::Source::Range]
   def determine_merged_range(corrections, source_buffer)
     min_begin_pos = corrections.map { |range, _| range.begin_pos }.min
     max_end_pos = corrections.map { |range, _| range.end_pos }.max
     Parser::Source::Range.new(source_buffer, min_begin_pos, max_end_pos)
   end
 
+  # @param [Array{Array}] corrections
+  # @param [Parser::Source::Buffer] source_buffer
+  # @param [Parser::Source::Range] merged_range
+  # @return [String]
   def build_corrected_text(corrections, source_buffer, merged_range)
     current_pos = merged_range.begin_pos
     corrected_text = ''
@@ -127,6 +134,8 @@ class RdjsonFormatter < RuboCop::Formatter::BaseFormatter
     corrected_text
   end
 
+  # @param [Parser::Source::Range] merged_range
+  # @return [Hash]
   def build_suggestion_range(merged_range)
     {
       start: {

--- a/rdjson_formatter/rdjson_formatter.rb
+++ b/rdjson_formatter/rdjson_formatter.rb
@@ -109,7 +109,7 @@ class RdjsonFormatter < RuboCop::Formatter::BaseFormatter
       next if range.end_pos <= min_begin_pos || range.begin_pos >= max_end_pos
 
       corrected_text += source_buffer.source[current_pos...range.begin_pos] if current_pos < range.begin_pos
-      corrected_text += replacement_text
+      corrected_text += replacement_text.to_s
       current_pos = range.end_pos
     end
 

--- a/rdjson_formatter/rdjson_formatter.rb
+++ b/rdjson_formatter/rdjson_formatter.rb
@@ -106,7 +106,7 @@ class RdjsonFormatter < RuboCop::Formatter::BaseFormatter
     sorted_corrections = corrections.sort_by { |range, _| range.begin_pos }
 
     sorted_corrections.each do |range, replacement_text|
-      next if range.end_pos <= min_begin_pos || range.begin_pos >= max_end_pos
+      next if range.end_pos < min_begin_pos || range.begin_pos > max_end_pos
 
       corrected_text += source_buffer.source[current_pos...range.begin_pos] if current_pos < range.begin_pos
       corrected_text += replacement_text.to_s

--- a/test/rdjson_formatter/testdata/correctable_offenses.rb
+++ b/test/rdjson_formatter/testdata/correctable_offenses.rb
@@ -1,4 +1,4 @@
-def add(xyz,abc)
+def add xyz,abc
   a    = xyz+   abc;
   return  a
 end

--- a/test/rdjson_formatter/testdata/result.ok
+++ b/test/rdjson_formatter/testdata/result.ok
@@ -41,6 +41,42 @@
       ]
     },
     {
+      "message": "Use def with parentheses when there are parameters.",
+      "location": {
+        "path": "test/rdjson_formatter/testdata/correctable_offenses.rb",
+        "range": {
+          "start": {
+            "line": 1,
+            "column": 9
+          },
+          "end": {
+            "line": 1,
+            "column": 16
+          }
+        }
+      },
+      "severity": "INFO",
+      "code": {
+        "value": "Style/MethodDefParentheses"
+      },
+      "original_output": "test/rdjson_formatter/testdata/correctable_offenses.rb:1:9: C: Style/MethodDefParentheses: Use def with parentheses when there are parameters.",
+      "suggestions": [
+        {
+          "range": {
+            "start": {
+              "line": 1,
+              "column": 8
+            },
+            "end": {
+              "line": 1,
+              "column": 16
+            }
+          },
+          "text": "(xyz,abc)"
+        }
+      ]
+    },
+    {
       "message": "Space missing after comma.",
       "location": {
         "path": "test/rdjson_formatter/testdata/correctable_offenses.rb",


### PR DESCRIPTION
The suggestions feature is broken as it's ignoring any offenses with multiple corrections. This is leading to wrong or - at best - incomplete sugggestions.

Fixes https://github.com/reviewdog/action-rubocop/issues/81 and https://github.com/reviewdog/action-rubocop/issues/96

Examples (before fix):
<img width="839" alt="Screenshot 2024-11-04 at 13 48 14" src="https://github.com/user-attachments/assets/7ff5873d-ae21-4e21-a54a-5095153287a2">
<img width="827" alt="Screenshot 2024-11-04 at 16 56 14" src="https://github.com/user-attachments/assets/94df60c5-78c7-4b80-ade1-7ec120dc51a7">

Examples (with fix):
<img width="826" alt="Screenshot 2024-11-04 at 16 45 18" src="https://github.com/user-attachments/assets/43222190-b509-4e70-8167-7ea5f69d8254">
<img width="812" alt="image" src="https://github.com/user-attachments/assets/181836af-9c2a-4a2c-b608-4e55dc64f205">

