### PR TITLE
Add Ruby development container setup with Rubocop integration

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,30 @@
+FROM ruby:3.3
+
+RUN apt-get update && apt-get install -y \
+  build-essential \
+  libssl-dev \
+  libreadline-dev \
+  zlib1g-dev \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN useradd -ms /bin/bash vscode
+
+WORKDIR /workspace
+
+RUN gem install bundler
+
+COPY . .
+
+RUN bundle install
+
+ENV RACK_ENV=development
+
+RUN apt-get update && apt-get install -y \
+  vim \
+  git \
+  jq \
+  && rm -rf /var/lib/apt/lists/*
+
+USER vscode
+
+CMD ["bash"]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,21 @@
+{
+  "name": "Ruby Development Container",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": ".."
+  },
+  "settings": {
+    "terminal.integrated.shell.linux": "/bin/bash"
+  },
+  "postCreateCommand": "bundle install",
+  "extensions": [
+    "rebornix.ruby",
+    "castwide.solargraph",
+    "wingrunr21.vscode-ruby",
+    "misogi.ruby-rubocop"
+  ],
+  "remoteUser": "vscode",
+  "remoteEnv": {
+    "RACK_ENV": "development"
+  }
+}

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'rubocop'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,36 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ast (2.4.2)
+    json (2.7.2)
+    language_server-protocol (3.17.0.3)
+    parallel (1.26.3)
+    parser (3.3.5.0)
+      ast (~> 2.4.1)
+      racc
+    racc (1.8.1)
+    rainbow (3.1.1)
+    regexp_parser (2.9.2)
+    rubocop (1.67.0)
+      json (~> 2.3)
+      language_server-protocol (>= 3.17.0)
+      parallel (~> 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 2.4, < 3.0)
+      rubocop-ast (>= 1.32.2, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 3.0)
+    rubocop-ast (1.32.3)
+      parser (>= 3.3.1.0)
+    ruby-progressbar (1.13.0)
+    unicode-display_width (2.6.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  rubocop
+
+BUNDLED WITH
+   2.5.7

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,16 +2,16 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
-    json (2.7.2)
+    json (2.8.1)
     language_server-protocol (3.17.0.3)
     parallel (1.26.3)
-    parser (3.3.5.0)
+    parser (3.3.6.0)
       ast (~> 2.4.1)
       racc
     racc (1.8.1)
     rainbow (3.1.1)
     regexp_parser (2.9.2)
-    rubocop (1.67.0)
+    rubocop (1.68.0)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
@@ -21,7 +21,7 @@ GEM
       rubocop-ast (>= 1.32.2, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 3.0)
-    rubocop-ast (1.32.3)
+    rubocop-ast (1.34.1)
       parser (>= 3.3.1.0)
     ruby-progressbar (1.13.0)
     unicode-display_width (2.6.0)
@@ -33,4 +33,4 @@ DEPENDENCIES
   rubocop
 
 BUNDLED WITH
-   2.5.7
+   2.5.23


### PR DESCRIPTION
This pull request sets up a development environment for Ruby using a Docker container and includes necessary configurations and dependencies.

This is especially needed in order to run the tests anywhere since they do not run on a MacOs environment for example.

Development environment setup:

* [`.devcontainer/Dockerfile`](diffhunk://#diff-13bd9d7a30bf46656bc81f1ad5b908a627f9247be3f7d76df862b0578b534fc6R1-R30): Created a Dockerfile to set up a Ruby development environment with necessary dependencies and tools.
* [`.devcontainer/devcontainer.json`](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686R1-R21): Added a configuration file for the development container, specifying extensions and settings for the VSCode environment.

Dependencies:

* [`Gemfile`](diffhunk://#diff-d09ea66f8227784ff4393d88a19836f321c915ae10031d16c93d67e6283ab55fR1-R3): Added `rubocop` gem to the Gemfile for Ruby code linting.