### PR TITLE
Update fail_on_error to fail_level in workflows

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -12,7 +12,7 @@ jobs:
         with:
           github_token: ${{ secrets.github_token }}
           reporter: github-pr-review
-          fail_on_error: true
+          fail_level: any
           locale: "US"
 
   shellcheck:
@@ -39,5 +39,5 @@ jobs:
         with:
           github_token: ${{ secrets.github_token }}
           reporter: github-pr-review
-          fail_on_error: true
+          fail_level: any
           yamllint_flags: '-d "{extends: default, rules: {truthy: disable}}" .'


### PR DESCRIPTION
`fail_on_error` flag is deprecated: https://github.com/reviewdog/action-misspell/pull/75 + https://github.com/reviewdog/action-yamllint/pull/45 + https://github.com/reviewdog/reviewdog/blob/master/CHANGELOG.md#rotating_light-deprecation-warnings