### PR TITLE
Fix git diff command to use relative path for changed files

### DIFF
--- a/script.sh
+++ b/script.sh
@@ -101,7 +101,7 @@ if [ "${INPUT_ONLY_CHANGED}" = "true" ]; then
   # shellcheck disable=SC2086
   readarray -t CHANGED_FILES < <(
     comm -12 \
-      <(git diff --diff-filter=d --name-only "${BASE_REF}..${HEAD_REF}" | sort || kill $$) \
+      <(git diff --relative --diff-filter=d --name-only "${BASE_REF}..${HEAD_REF}" | sort || kill $$) \
       <(${BUNDLE_EXEC}rubocop --list-target-files | sort || kill $$)
   )
 


### PR DESCRIPTION
## 🐛 Problem: No files matched when using `only_changed` in monorepos

### Context

When using this action in a **monorepo** setup like this:

- `reviewdog/action-rubocop@v2.21.2`
- Configuration:
  ```yaml
  workdir: apps/rails_application
  only_changed: true
  ```

### Observed behavior

The action always outputs:
```
No relevant files for rubocop, skipping
```

This happens **even when files are definitely changed inside the workdir.**

---

### Root Cause

In [`script.sh`](https://github.com/reviewdog/action-rubocop/blob/master/script.sh), when `only_changed: true` is enabled, the list of changed files is determined with:

```bash
readarray -t CHANGED_FILES < <(
  comm -12 \
    <(git diff --diff-filter=d --name-only "${BASE_REF}..${HEAD_REF}" | sort || kill $$) \
    <(${BUNDLE_EXEC}rubocop --list-target-files | sort || kill $$)
)
```

The issue is:  
- `git diff` returns file paths **relative to the git root**
- `rubocop --list-target-files` returns paths **relative to the `workdir`**

So even if both sets contain the same changed file, they don’t match.

---

### ✅ Solution

Add the `--relative` flag to the `git diff` command:

```diff
- <(git diff --diff-filter=d --name-only "${BASE_REF}..${HEAD_REF}" | sort || kill $$) \
+ <(git diff --relative --diff-filter=d --name-only "${BASE_REF}..${HEAD_REF}" | sort || kill $$) \
```

This ensures both sets of file paths are relative to the same working directory and can be compared correctly.

---

### 🧪 Testing

This change was tested in a real-world monorepo setup within a private project I work on.
The GitHub Action now correctly detects changed files for rubocop when using:
- `workdir: ...`
- `only_changed: true`

After applying the fix (`--relative`), the issue is resolved and `rubocop` correctly analyzes changed files within the subdirectory.
